### PR TITLE
Update labels.j2: remove duplicate server port configuration

### DIFF
--- a/templates/labels.j2
+++ b/templates/labels.j2
@@ -35,7 +35,6 @@ traefik.http.routers.{{ prometheus_identifier }}.tls.certResolver={{ prometheus_
 traefik.http.routers.{{ prometheus_identifier }}.entrypoints={{ prometheus_container_labels_traefik_entrypoints }}
 {% endif %}
 
-traefik.http.services.{{ prometheus_identifier }}.loadbalancer.server.port=9100
 traefik.http.services.{{ prometheus_identifier }}.loadbalancer.server.port={{ prometheus_container_http_port }}
 
 {{ prometheus_container_labels_additional_labels }}


### PR DESCRIPTION
[`prometheus_container_http_port`](https://github.com/mother-of-all-self-hosting/ansible-role-prometheus/blob/fd96f762b6866d4fedc288e17da9e770028dff73/defaults/main.yml#L50) is set to 9090 on defaults/main.yml and this hardcoded value does not seem to have been effective.